### PR TITLE
Sort entity picker dropdown by friendly name

### DIFF
--- a/src/trend-analysis-card.ts
+++ b/src/trend-analysis-card.ts
@@ -223,7 +223,17 @@ export class TrendAnalysisCard extends LitElement {
                 const stateValue = parseFloat(state.state);
                 return !isNaN(stateValue) && state.state !== 'unknown' && state.state !== 'unavailable';
             })
-            .sort();
+            .sort((a, b) => {
+                const stateA = this._hass.states[a];
+                const stateB = this._hass.states[b];
+
+                // Use friendly_name if available, otherwise fall back to entity ID
+                const nameA = stateA?.attributes?.friendly_name?.trim() || a;
+                const nameB = stateB?.attributes?.friendly_name?.trim() || b;
+
+                // Case-insensitive comparison using locale-aware sorting
+                return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' });
+            });
     }
 
     private renderHeader(): Template {


### PR DESCRIPTION
The entity picker dropdown was sorting entities by their entity ID (e.g., sensor.apollo_air_1_garage) but displaying their friendly names (e.g., "Apollo AIR-1 Garage SEN55"), making the list appear unsorted to users.

Modified _getNumericEntities() to sort by the displayed friendly name with case-insensitive comparison, falling back to entity ID when friendly_name is not available.

This references Issue #11 