### PR TITLE
feat: add percentage change display with configurable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ showDatePickers: false
 | **showPresets**     | `boolean`            | ❌ No     | `true`     | Whether to display quick range selection buttons (24h, 7d, 30d).                                                                         |
 | **showDatePickers** | `boolean`            | ❌ No     | `true`     | Whether to display the date range picker for manual selection.                                                                           |
 | **showGraph**       | `boolean`            | ❌ No     | `true`     | Whether to display the graph of increases and decreases.                                                                                 |
+| **showPercentage**  | `boolean`            | ❌ No     | `false`    | Whether to display percentage changes alongside absolute values.                                                                         |
+| **percentageOnly**  | `boolean`            | ❌ No     | `false`    | Show only percentages, hide absolute values.                                                                                             |
 
 ---
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -221,6 +221,24 @@
     font-weight: 500;
 }
 
+.percentage {
+    font-size: 28px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.percentage.up {
+    color: var(--trend-increase-light);
+}
+
+.percentage.down {
+    color: var(--trend-decrease-light);
+}
+
+.percentage.neutral {
+    color: var(--trend-neutral);
+}
+
 .stats-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -322,6 +340,20 @@
 .stat-unit {
     font-size: 14px;
     color: var(--trend-text-primary);
+}
+
+.stat-percentage {
+    font-size: 20px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.stat-card.increase .stat-percentage {
+    color: var(--trend-increase-light);
+}
+
+.stat-card.decrease .stat-percentage {
+    color: var(--trend-decrease-light);
 }
 
 .progress-bar {
@@ -649,6 +681,14 @@
 
     .stat-value {
         font-size: 24px;
+    }
+
+    .percentage {
+        font-size: 28px;
+    }
+
+    .stat-percentage {
+        font-size: 16px;
     }
 
     .preset-buttons {

--- a/src/trend-analysis-card.ts
+++ b/src/trend-analysis-card.ts
@@ -115,6 +115,12 @@ export class TrendAnalysisCard extends LitElement {
             }
             if (data.length != 0) {
                 const netChange = data[data.length - 1].v - data[0].v;
+                const firstValue = data[0].v;
+
+                const deltaPercent = firstValue !== 0 ? (netChange / firstValue) * 100 : (netChange !== 0 ? (netChange > 0 ? 100 : -100) : 0);
+                const increasePercent = increase !== 0 ? (increase / Math.abs(firstValue || 1)) * 100 : 0;
+                const decreasePercent = decrease !== 0 ? (decrease / Math.abs(firstValue || 1)) * 100 : 0;
+
                 this._result = {
                     start: data[0].t,
                     end: data[data.length - 1].t,
@@ -123,6 +129,9 @@ export class TrendAnalysisCard extends LitElement {
                     increase: increase,
                     decrease: decrease,
                     delta: netChange,
+                    deltaPercent: deltaPercent,
+                    increasePercent: increasePercent,
+                    decreasePercent: decreasePercent,
                     trend: netChange > 0 ? "up" : netChange < 0 ? "down" : "neutral",
                     graphData: this._prepareGraphData(data)
                 };
@@ -304,6 +313,8 @@ export class TrendAnalysisCard extends LitElement {
 
         const entityState = this._hass.states[this._config.entity];
         const unit = entityState?.attributes?.unit_of_measurement || '';
+        const showPercentage = this._config.showPercentage === true;
+        const percentageOnly = this._config.percentageOnly === true;
 
         const data = this._result;
         const increasePercent = (data.increase / (data.increase + data.decrease)) * 100;
@@ -329,8 +340,13 @@ export class TrendAnalysisCard extends LitElement {
                     }
                 </div>
                 <div class="value-container">
-                    <span class="main-value ${data.trend}">${data.delta.toFixed(2)}</span>
-                    <span class="unit">${unit}</span>
+                    ${!percentageOnly ? html`
+                        <span class="main-value ${data.trend}">${data.delta.toFixed(2)}</span>
+                        <span class="unit">${unit}</span>
+                    ` : nothing}
+                    ${showPercentage ? html`
+                        <span class="percentage ${data.trend}">${data.deltaPercent !== undefined ? data.deltaPercent.toFixed(1) : '0.0'}%</span>
+                    ` : nothing}
                 </div>
             </div>
 
@@ -343,8 +359,13 @@ export class TrendAnalysisCard extends LitElement {
                         <span class="stat-label increase">${localize('common.total_increase')}</span>
                     </div>
                     <div class="stat-value-container">
-                        <span class="stat-value">${data.increase.toFixed(2)}</span>
-                        <span class="stat-unit">${unit}</span>
+                        ${!percentageOnly ? html`
+                            <span class="stat-value">${data.increase.toFixed(2)}</span>
+                            <span class="stat-unit">${unit}</span>
+                        ` : nothing}
+                        ${showPercentage ? html`
+                            <span class="stat-percentage">+${data.increasePercent !== undefined ? data.increasePercent.toFixed(1) : '0.0'}%</span>
+                        ` : nothing}
                     </div>
                     <div class="progress-bar">
                         <div class="progress-fill increase" style="width: calc(${increasePercent.toFixed(0)}%)"></div>
@@ -359,8 +380,13 @@ export class TrendAnalysisCard extends LitElement {
                         <span class="stat-label decrease">${localize('common.total_decrease')}</span>
                     </div>
                     <div class="stat-value-container">
-                        <span class="stat-value">${data.decrease.toFixed(2)}</span>
-                        <span class="stat-unit">${unit}</span>
+                        ${!percentageOnly ? html`
+                            <span class="stat-value">${data.decrease.toFixed(2)}</span>
+                            <span class="stat-unit">${unit}</span>
+                        ` : nothing}
+                        ${showPercentage ? html`
+                            <span class="stat-percentage">-${data.decreasePercent !== undefined ? data.decreasePercent.toFixed(1) : '0.0'}%</span>
+                        ` : nothing}
                     </div>
                     <div class="progress-bar">
                         <div class="progress-fill decrease" style="width: calc(${decreasePercent.toFixed(0)}%)"></div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,9 @@ export interface TrendResult {
     increase: number;
     decrease: number;
     delta: number;
+    deltaPercent?: number;
+    increasePercent?: number;
+    decreasePercent?: number;
     trend: 'up' | 'down' | 'neutral';
     graphData: number[];
 }
@@ -39,4 +42,6 @@ export interface CardConfig {
     showPresets?: boolean;
     showDatePickers?: boolean;
     showGraph?: boolean;
+    showPercentage?: boolean;
+    percentageOnly?: boolean;
 }


### PR DESCRIPTION
You can now display trends as both absolute values and percentages.                                                                                                                                                     
                
`showPercentage` (default: `false`)
- When true, displays percentage changes alongside net change, total increase, and total decrease values
- Example: +5.2 °C (+12.5%)

`percentageOnly` (default: `false`)
- When true, shows only percentages, hiding absolute values
- Used in combination with showPercentage: true            
- Example: displays only +12.5%
                                                                                                                                                                                                                        
Usage example:
```
type: custom:trend-analysis-card                                                                                                                                                                                        
entity: sensor.temperature
showPercentage: true
percentageOnly: false
```